### PR TITLE
Fix error : AuthorizerProvider should know it can accept childe components

### DIFF
--- a/src/contexts/AuthorizerContext.tsx
+++ b/src/contexts/AuthorizerContext.tsx
@@ -95,6 +95,7 @@ let initialState: AuthorizerState = {
 };
 
 export const AuthorizerProvider: FC<{
+  children: React.ReactNode;
   config: {
     authorizerURL: string;
     redirectURL: string;


### PR DESCRIPTION
Hi @lakhansamani, I just wanted to use the AuthorizerProvider in the same way you did in the example. 

I'm using typescript. 

```
        <AuthorizerProvider
          config={{
            authorizerURL: '-,
            redirectURL: '-',
            clientID: '-',
          }}
        >
          <Header />
          <Routes>
            <Route path='/' element={<Home />} />
            <Route path='/about-us' element={<AboutUs />} />
            <Route path='/contact-us' element={<ContactUs />} />
          </Routes>
          <Footer />
        </AuthorizerProvider>
```
But I only get the error below:

```
 Type '{ children: Element[]; config: { authorizerURL: string; redirectURL: string; clientID: string; }; }' is not assignable to type 'IntrinsicAttributes & { config: { authorizerURL: string; redirectURL: string; clientID?: string | undefined; }; onStateChangeCallback?: ((stateData: AuthorizerState) => Promise<...>) | undefined; }'.
  Property 'children' does not exist on type 'IntrinsicAttributes & { config: { authorizerURL: string; redirectURL: string; clientID?: string | undefined; }; onStateChangeCallback?: ((stateData: AuthorizerState) => Promise<...>) | undefined; }'.
```

I could fix this error after I added child type for `AuthorizerProvider`. 

Hopefully this be accepted and merged to main code base if there is no problem. :) 
Thank you for all those work for this project. Such a nice project.
