### PR TITLE
fixing bug with hasSpecialChar password validation

### DIFF
--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -52,7 +52,7 @@ export const validatePassword = (
     } else if (char >= '0' && char <= '9' && !res.hasNumericChar) {
       res.score = res.score + 1;
       res.hasNumericChar = true;
-    } else if (!res.hasSpecialChar) {
+    } else if (res.hasSpecialChar) {
       res.score = res.score + 1;
       res.hasSpecialChar = true;
     }


### PR DESCRIPTION
I noticed that the react password validation component marks passwords without special character incorrectly as passwords that include a special character. 