### PR TITLE
feat/totp_screen_inside_verify_otp_page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@authorizerdev/authorizer-react",
-  "version": "1.2.0-beta.7",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@authorizerdev/authorizer-react",
-      "version": "1.2.0-beta.7",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@authorizerdev/authorizer-js": "^2.0.0-beta.3",


### PR DESCRIPTION
#### What does this PR do ?
- Implement TOTP scanner flow in the OTP verification page upon TOTP secret reset (when the user uses the recovery code to log in) 
- Needs to be released before merging :
https://github.com/authorizerdev/authorizer/pull/445