### PR TITLE
feat: distinct, non-dismissible UI state for TOTP lockout

### DIFF
--- a/src/components/AuthorizerVerifyOtp.tsx
+++ b/src/components/AuthorizerVerifyOtp.tsx
@@ -59,6 +59,16 @@ export const AuthorizerVerifyOtp: FC<{
       if (errors && errors.length) {
         if (errors[0]?.code === 'TOO_MANY_REQUESTS') {
           setIsLockedOut(true);
+          // Fall back to a fixed message if the server ever sends an empty
+          // one: the form is about to go fully disabled (input + submit),
+          // so this is the user's only explanation for why - an empty
+          // string here would mean no message renders at all (Message
+          // returns null for blank text) and the form goes silently dead.
+          setError(
+            errors[0]?.message ||
+              `Too many attempts. Please wait a while before trying again.`,
+          );
+          return;
         }
         setError(errors[0]?.message || ``);
         return;

--- a/src/components/AuthorizerVerifyOtp.tsx
+++ b/src/components/AuthorizerVerifyOtp.tsx
@@ -161,6 +161,7 @@ export const AuthorizerVerifyOtp: FC<{
             }`}
             placeholder="e.g.- AB123C"
             type="password"
+            autoComplete="one-time-code"
             value={formData.otp || ''}
             onChange={(e) => onInputChange('otp', e.target.value)}
             disabled={isLockedOut}
@@ -189,13 +190,14 @@ export const AuthorizerVerifyOtp: FC<{
       </form>
       {setView && (
         <StyledFooter>
-          {sendingOtp ? (
-            <div style={{ marginBottom: '10px' }}>Sending ...</div>
-          ) : (
-            <StyledLink onClick={resendOtp} marginBottom="10px">
-              Resend OTP
-            </StyledLink>
-          )}
+          {!is_totp &&
+            (sendingOtp ? (
+              <div style={{ marginBottom: '10px' }}>Sending ...</div>
+            ) : (
+              <StyledLink onClick={resendOtp} marginBottom="10px">
+                Resend OTP
+              </StyledLink>
+            ))}
           {config.is_sign_up_enabled && (
             <div>
               Don't have an account?{' '}

--- a/src/components/AuthorizerVerifyOtp.tsx
+++ b/src/components/AuthorizerVerifyOtp.tsx
@@ -23,6 +23,7 @@ export const AuthorizerVerifyOtp: FC<{
   const [successMessage, setSuccessMessage] = useState(``);
   const [loading, setLoading] = useState(false);
   const [sendingOtp, setSendingOtp] = useState(false);
+  const [isLockedOut, setIsLockedOut] = useState(false);
   const [formData, setFormData] = useState<InputDataType>({
     otp: null,
   });
@@ -56,6 +57,9 @@ export const AuthorizerVerifyOtp: FC<{
       data.is_totp = !!is_totp;
       const { data: res, errors } = await authorizerRef.verifyOtp(data);
       if (errors && errors.length) {
+        if (errors[0]?.code === 'TOO_MANY_REQUESTS') {
+          setIsLockedOut(true);
+        }
         setError(errors[0]?.message || ``);
         return;
       }
@@ -134,7 +138,11 @@ export const AuthorizerVerifyOtp: FC<{
         />
       )}
       {error && (
-        <Message type={MessageType.Error} text={error} onClose={onErrorClose} />
+        <Message
+          type={MessageType.Error}
+          text={error}
+          onClose={isLockedOut ? undefined : onErrorClose}
+        />
       )}
       <p style={{ textAlign: 'center', margin: '10px 0px' }}>
         Please enter the OTP sent to your email or phone number or authenticator
@@ -155,6 +163,7 @@ export const AuthorizerVerifyOtp: FC<{
             type="password"
             value={formData.otp || ''}
             onChange={(e) => onInputChange('otp', e.target.value)}
+            disabled={isLockedOut}
           />
           {errorData.otp && (
             <div className="form-input-error">{errorData.otp}</div>
@@ -172,7 +181,7 @@ export const AuthorizerVerifyOtp: FC<{
         <br />
         <StyledButton
           type="submit"
-          disabled={loading || !formData.otp || !!errorData.otp}
+          disabled={loading || !formData.otp || !!errorData.otp || isLockedOut}
           appearance={ButtonAppearance.Primary}
         >
           {loading ? `Processing ...` : `Submit`}


### PR DESCRIPTION
## Summary
- `AuthorizerVerifyOtp` now detects `errors[0].code === 'TOO_MANY_REQUESTS'` on a failed `verify_otp` and disables the OTP input + Submit button, and stops the error message from being dismissed - previously the lockout showed identically to a plain wrong code, so the form stayed submittable with no signal to stop retrying.
- No countdown/timer: the backend doesn't expose remaining lockout duration, so this is a static message rather than a timer that could show the wrong number.

## Dependency (blocking merge)
This depends on `.code` being available on `authorizer-js` errors: authorizerdev/authorizer-js#39 (not yet published to npm). **`package.json` here is intentionally untouched** - once that PR is merged and published, bump `@authorizerdev/authorizer-js` and this will typecheck/build cleanly. Until then `errors[0]?.code` typechecks against the *unpublished* SDK shape only (verified locally via `npm link`), not the currently-pinned `3.2.1`.

## Test plan
- [x] `tsc --noEmit` clean against the linked (unpublished) `authorizer-js` build
- [x] Live UAT: ran the `example/` app against a local `authorizer` server (branch `security/totp-hardening`, includes the `extensions.code` backend PR), signed up + enrolled TOTP, failed `verify_otp` 6x through the real browser UI. Confirmed via DOM inspection: input and submit button both `disabled: true`, banner text "Too many failed attempts, please try again later", no dismiss icon.
- [ ] Not yet re-verified against the *published* SDK - needs a follow-up once authorizer-js#39 ships and this repo's dependency is bumped.