### PR TITLE
chore: release 2.2.0-rc.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0",
+  "version": "2.2.0-rc.0",
   "license": "MIT",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
RC release so the login UI can be e2e-tested end to end.

- **2.2.0-rc.0** on `@authorizerdev/authorizer-js@3.3.0-rc.0`.
- Ships passkey login (#54) and the non-dismissible TOTP-lockout UI (#53), on top of the TOTP-screen-in-verify-otp (#55).

Tagging `v2.2.0-rc.0` after merge publishes to npm under the `rc` dist-tag (`npm i @authorizerdev/authorizer-react@rc`).