### PR TITLE
fix(ci): CI-safe npm publish on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,17 @@ jobs:
               run: make build
 
             - name: Publish to npm
+              # Publish directly here. The Makefile publish-rc/publish targets
+              # are interactive (confirm prompt) and re-do the commit/tag/push —
+              # correct for a human running the whole release locally, but they
+              # hang/cancel in CI, which fires AFTER the tag already exists.
               run: |
-                  if [[ "${{ github.ref }}" =~ -rc\.[0-9]+$ ]]; then
-                    make publish-rc
+                  if [[ "${GITHUB_REF_NAME}" == *-rc.* ]]; then
+                    npm publish --tag rc --access public
+                  elif [[ "${GITHUB_REF_NAME}" == *-beta.* ]]; then
+                    npm publish --tag beta --access public
                   else
-                    make publish
+                    npm publish --access public
                   fi
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The release workflow could never auto-publish: it called `make publish-rc`/`make publish`, which are **interactive** (a `read -p "Continue? (y/N)"` prompt) and also re-do commit/tag/push. In CI there's no TTY, so the prompt defaults to No and the publish is cancelled (this is why the `v2.2.0-rc.0` release run failed). This publishes directly, routing `-rc.`/`-beta.` tags to the `rc`/`beta` dist-tag so a prerelease never lands on `latest`.

**Second, separate blocker (needs a repo admin — I can't do it):** the `NPM_TOKEN` secret is **not set** in this repo. The `v2.2.0-rc.0` release run showed `NODE_AUTH_TOKEN:` blank (the authorizer-js repo has it and published fine). Set `NPM_TOKEN` in repo Settings → Secrets, then re-run the release for tag `v2.2.0-rc.0` (or re-push the tag) and it will publish 2.2.0-rc.0 to the `rc` dist-tag.

Interim: a maintainer can publish now with `npm ci && npm run build && npm publish --tag rc --access public` locally (version + tag are already on main).