### PR TITLE
feat(mfa): offer passkey enrollment during the login-time MFA setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@authorizerdev/authorizer-react",
-  "version": "2.2.0-rc.0",
+  "version": "2.2.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@authorizerdev/authorizer-react",
-      "version": "2.2.0-rc.0",
+      "version": "2.2.0-rc.1",
       "license": "MIT",
       "dependencies": {
-        "@authorizerdev/authorizer-js": "^3.3.0-rc.1",
+        "@authorizerdev/authorizer-js": "^3.3.0-rc.2",
         "@storybook/preset-scss": "^1.0.3",
         "validator": "^13.11.0"
       },
@@ -73,9 +73,9 @@
       }
     },
     "node_modules/@authorizerdev/authorizer-js": {
-      "version": "3.3.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-3.3.0-rc.1.tgz",
-      "integrity": "sha512-L6S2BzHIP7cPa4nD3FT2RxRiQM5w6jauCNtEX+5t+8sUr4DrrcZON2MhYhVSuBT8+8/Y9TcKO2ZamZwuDX0pVg==",
+      "version": "3.3.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-3.3.0-rc.2.tgz",
+      "integrity": "sha512-mukoMoDzjcyEWzsjMA50UwVEhsEbC2G1HnY6NMTnZ3x4puDI98PHpkd3R292jlYLjpE6aj4iO+2pMq0cUrVKlA==",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0-rc.0",
+  "version": "2.2.0-rc.1",
   "license": "MIT",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
@@ -91,7 +91,7 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@authorizerdev/authorizer-js": "^3.3.0-rc.1",
+    "@authorizerdev/authorizer-js": "^3.3.0-rc.2",
     "@storybook/preset-scss": "^1.0.3",
     "validator": "^13.11.0"
   }

--- a/src/components/AuthorizerBasicAuthLogin.tsx
+++ b/src/components/AuthorizerBasicAuthLogin.tsx
@@ -26,6 +26,7 @@ type MfaOfferData = {
   email: string;
   phone_number: string;
   totpEnrollment: TotpEnrollment | null;
+  passkey: boolean;
   emailOtp: boolean;
   smsOtp: boolean;
   state?: string;
@@ -36,6 +37,7 @@ const initMfaOfferData: MfaOfferData = {
   email: '',
   phone_number: '',
   totpEnrollment: null,
+  passkey: false,
   emailOtp: false,
   smsOtp: false,
 };
@@ -124,6 +126,7 @@ export const AuthorizerBasicAuthLogin: FC<{
           email: data.email || ``,
           phone_number: data.phone_number || ``,
           totpEnrollment: step.totpEnrollment,
+          passkey: step.passkey,
           emailOtp: step.emailOtp,
           smsOtp: step.smsOtp,
           state: urlProps?.state,
@@ -204,7 +207,7 @@ export const AuthorizerBasicAuthLogin: FC<{
       <AuthorizerMFASetup
         availableMfaMethods={{
           totp: !!mfaOfferData.totpEnrollment || config.is_totp_mfa_enabled,
-          passkey: false,
+          passkey: mfaOfferData.passkey,
           emailOtp: mfaOfferData.emailOtp,
           smsOtp: mfaOfferData.smsOtp,
         }}

--- a/src/components/AuthorizerBasicAuthLogin.tsx
+++ b/src/components/AuthorizerBasicAuthLogin.tsx
@@ -8,6 +8,7 @@ import { ButtonAppearance, MessageType, Views } from '../constants';
 import { useAuthorizer } from '../contexts/AuthorizerContext';
 import { StyledButton, StyledFooter, StyledLink } from '../styledComponents';
 import { Message } from './Message';
+import { PasswordInput } from './PasswordInput';
 import { AuthorizerVerifyOtp } from './AuthorizerVerifyOtp';
 import { OtpDataType } from '../types';
 import { AuthorizerMFASetup } from './AuthorizerMFASetup';
@@ -47,12 +48,20 @@ interface InputDataType {
   password: string | null;
 }
 
+export type BasicAuthLoginStep = 'form' | 'mfa-setup' | 'otp-verify' | 'locked';
+
 export const AuthorizerBasicAuthLogin: FC<{
   setView?: (v: Views) => void;
   onLogin?: (data: AuthToken | void) => void;
   urlProps?: Record<string, any>;
   roles?: string[];
-}> = ({ setView, onLogin, urlProps, roles }) => {
+  // Fired whenever this component switches between its own screens. See
+  // AuthorizerSignup's identical prop for why hosts need this: a successful
+  // login that still needs MFA setup/verification takes over the whole
+  // login surface - other login options (social buttons, passkey button)
+  // don't belong stacked on top of those screens.
+  onStepChange?: (step: BasicAuthLoginStep) => void;
+}> = ({ setView, onLogin, urlProps, roles, onStepChange }) => {
   const [error, setError] = useState(``);
   const [loading, setLoading] = useState(false);
   const [otpData, setOtpData] = useState<OtpDataType>({ ...initOtpData });
@@ -69,6 +78,19 @@ export const AuthorizerBasicAuthLogin: FC<{
     password: null,
   });
   const { setAuthData, config, authorizerRef } = useAuthorizer();
+
+  useEffect(() => {
+    if (!onStepChange) return;
+    if (locked) {
+      onStepChange('locked');
+    } else if (mfaOfferData.is_screen_visible) {
+      onStepChange('mfa-setup');
+    } else if (otpData.is_screen_visible) {
+      onStepChange('otp-verify');
+    } else {
+      onStepChange('form');
+    }
+  }, [locked, mfaOfferData.is_screen_visible, otpData.is_screen_visible]);
 
   const onInputChange = async (field: string, value: string) => {
     setFormData({ ...formData, [field]: value });
@@ -213,6 +235,7 @@ export const AuthorizerBasicAuthLogin: FC<{
         }}
         totpEnrollment={mfaOfferData.totpEnrollment || undefined}
         heading="Set up multi-factor authentication"
+        onBack={() => setMfaOfferData({ ...initMfaOfferData })}
         loginContext={{
           email: mfaOfferData.email,
           phone_number: mfaOfferData.phone_number,
@@ -244,6 +267,7 @@ export const AuthorizerBasicAuthLogin: FC<{
           is_totp: otpData.is_totp || false,
           offerWebauthnVerify: otpData.offer_webauthn_verify || false,
           hasCodeFactor: otpData.has_code_factor || false,
+          onBack: () => setOtpData({ ...initOtpData }),
         }}
         urlProps={urlProps}
       />
@@ -285,28 +309,15 @@ export const AuthorizerBasicAuthLogin: FC<{
               </div>
             )}
           </div>
-          <div className="styled-form-group">
-            <label
-              className="form-input-label"
-              htmlFor="authorizer-login-password"
-            >
-              <span>* </span>Password
-            </label>
-            <input
-              name="password"
-              id="authorizer-login-password"
-              className={`form-input-field ${
-                errorData.password ? 'input-error-content' : ''
-              }`}
-              placeholder="********"
-              type="password"
-              value={formData.password || ''}
-              onChange={e => onInputChange('password', e.target.value)}
-            />
-            {errorData.password && (
-              <div className="form-input-error">{errorData.password}</div>
-            )}
-          </div>
+          <PasswordInput
+            id="authorizer-login-password"
+            name="password"
+            label="Password"
+            autoComplete="current-password"
+            value={formData.password || ''}
+            onChange={(value) => onInputChange('password', value)}
+            error={errorData.password}
+          />
           <br />
           <StyledButton
             type="submit"

--- a/src/components/AuthorizerMFASetup.tsx
+++ b/src/components/AuthorizerMFASetup.tsx
@@ -120,7 +120,7 @@ export const AuthorizerMFASetup: FC<{
     },
     {
       key: 'passkey',
-      available: !!availableMfaMethods.passkey && !loginContext,
+      available: !!availableMfaMethods.passkey,
       icon: <IconPasskey />,
       title: 'Passkey',
       description: 'Sign in with your fingerprint, face, or device PIN.',
@@ -308,7 +308,27 @@ export const AuthorizerMFASetup: FC<{
       <>
         <BackLink onClick={backToList} />
         <p style={{ margin: '10px 0px', fontWeight: 'bold' }}>Add a passkey</p>
-        <AuthorizerPasskeyRegister onSuccess={backToList} showCredentials />
+        <AuthorizerPasskeyRegister
+          // showCredentials calls webauthn_credentials, which requires a
+          // bearer token - never available yet during a login-time offer.
+          showCredentials={!loginContext}
+          mfaSetup={
+            loginContext
+              ? {
+                  email: loginContext.email,
+                  phoneNumber: loginContext.phone_number,
+                  state: loginContext.state,
+                }
+              : undefined
+          }
+          onSuccess={(data) => {
+            if (loginContext && data && (data as AuthTokenLike).access_token) {
+              loginContext.onComplete(data as AuthTokenLike);
+              return;
+            }
+            backToList();
+          }}
+        />
       </>
     );
   }

--- a/src/components/AuthorizerMFASetup.tsx
+++ b/src/components/AuthorizerMFASetup.tsx
@@ -11,22 +11,12 @@ import {
 } from '../icons/mfa';
 import { StyledButton } from '../styledComponents';
 import { Message } from './Message';
+import { BackLink } from './BackLink';
 import { AuthorizerTOTPScanner } from './AuthorizerTOTPScanner';
 import { AuthorizerPasskeyRegister } from './AuthorizerPasskeyRegister';
 import { AuthorizerVerifyOtp } from './AuthorizerVerifyOtp';
 import { useAuthorizer } from '../contexts/AuthorizerContext';
 import { TotpEnrollment } from '../utils/mfaTriage';
-
-const BackLink: FC<{ onClick: () => void }> = ({ onClick }) => (
-  <button
-    type="button"
-    className="mfa-icon-button"
-    onClick={onClick}
-    style={{ border: 'none', background: 'none', padding: '4px 0' }}
-  >
-    &larr; All methods
-  </button>
-);
 
 export type MfaMethod = 'totp' | 'passkey' | 'email_otp' | 'sms_otp';
 
@@ -76,12 +66,24 @@ export const AuthorizerMFASetup: FC<{
     state?: string;
     onComplete: (response: AuthTokenLike) => void;
   };
+  // When present, a "Back" link is shown on the top-level method list so the
+  // host can let the user leave MFA setup entirely (distinct from BackLink's
+  // existing "All methods" links, which only return from a method's
+  // sub-flow to this same list).
+  onBack?: () => void;
+  // Whether the signed-in user already has at least one passkey registered
+  // (the host knows this via webauthnCredentials - there's no per-user
+  // enrolment signal for TOTP/email-OTP/SMS-OTP available to the client, so
+  // only passkey can be accurately highlighted as already set up).
+  passkeyRegistered?: boolean;
 }> = ({
   availableMfaMethods,
   totpEnrollment,
   onSetupMethod,
   heading = 'Add a second step to sign in',
   loginContext,
+  onBack,
+  passkeyRegistered,
 }) => {
   const [selected, setSelected] = useState<MfaMethod | null>(null);
   const [notice, setNotice] = useState('');
@@ -110,6 +112,7 @@ export const AuthorizerMFASetup: FC<{
     description: string;
     disabled?: boolean;
     disabledReason?: string;
+    enabled?: boolean;
   }[] = [
     {
       key: 'totp',
@@ -126,6 +129,7 @@ export const AuthorizerMFASetup: FC<{
       description: 'Sign in with your fingerprint, face, or device PIN.',
       disabled: !passkeySupported,
       disabledReason: 'Not supported on this browser or device.',
+      enabled: !!passkeyRegistered,
     },
     {
       key: 'email_otp',
@@ -264,12 +268,11 @@ export const AuthorizerMFASetup: FC<{
   if (selected === 'totp' && effectiveTotpEnrollment) {
     return (
       <>
-        <BackLink onClick={backToList} />
+        <BackLink onClick={backToList} label="All methods" />
         <AuthorizerTOTPScanner
           {...effectiveTotpEnrollment}
           email={loginContext?.email}
           phone_number={loginContext?.phone_number}
-          setView={backToList}
           onLogin={(data) => {
             if (loginContext && data && (data as AuthTokenLike).access_token) {
               loginContext.onComplete(data as AuthTokenLike);
@@ -285,7 +288,7 @@ export const AuthorizerMFASetup: FC<{
   if (otpMethodPending) {
     return (
       <>
-        <BackLink onClick={() => setOtpMethodPending(null)} />
+        <BackLink onClick={() => setOtpMethodPending(null)} label="All methods" />
         <AuthorizerVerifyOtp
           email={loginContext?.email}
           phone_number={loginContext?.phone_number}
@@ -306,7 +309,7 @@ export const AuthorizerMFASetup: FC<{
   if (selected === 'passkey') {
     return (
       <>
-        <BackLink onClick={backToList} />
+        <BackLink onClick={backToList} label="All methods" />
         <p style={{ margin: '10px 0px', fontWeight: 'bold' }}>Add a passkey</p>
         <AuthorizerPasskeyRegister
           // showCredentials calls webauthn_credentials, which requires a
@@ -335,6 +338,7 @@ export const AuthorizerMFASetup: FC<{
 
   return (
     <>
+      {onBack && <BackLink onClick={onBack} />}
       <p style={{ margin: '10px 0px', fontWeight: 'bold' }}>{heading}</p>
       {notice && (
         <Message
@@ -359,10 +363,18 @@ export const AuthorizerMFASetup: FC<{
       ) : (
         <ul className="mfa-list" aria-label="Available multi-factor methods">
           {visibleMethods.map((m) => (
-            <li key={m.key} className="mfa-method">
+            <li
+              key={m.key}
+              className={`mfa-method${m.enabled ? ' mfa-method-enabled' : ''}`}
+            >
               <span className="mfa-method-icon">{m.icon}</span>
               <div className="mfa-method-body">
-                <p className="mfa-method-title">{m.title}</p>
+                <p className="mfa-method-title">
+                  {m.title}
+                  {m.enabled && (
+                    <span className="mfa-method-badge">Enabled</span>
+                  )}
+                </p>
                 <p className="mfa-method-desc">
                   {m.disabled && m.disabledReason
                     ? m.disabledReason
@@ -377,7 +389,7 @@ export const AuthorizerMFASetup: FC<{
                   onClick={() => handleSetup(m.key)}
                   style={{ width: 'auto' }}
                 >
-                  Set up
+                  {m.enabled ? 'Manage' : 'Set up'}
                 </StyledButton>
               </div>
             </li>

--- a/src/components/AuthorizerPasskeyLogin.tsx
+++ b/src/components/AuthorizerPasskeyLogin.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { AuthToken, isWebauthnSupported } from '@authorizerdev/authorizer-js';
 
 import '../styles/default.css';
@@ -46,11 +46,30 @@ const PasskeyIcon: FC = () => (
 
 export const AuthorizerPasskeyLogin: FC<{
   onLogin?: (data: AuthToken | void) => void;
-}> = ({ onLogin }) => {
+  // Fired whenever this component switches between its own button and its
+  // internal MFA offer/verify/locked screens. A passkey-primary login that
+  // needs a second factor takes over the whole login surface - hosts
+  // rendering other login options (social buttons, password form) alongside
+  // this component need this to hide them while an MFA screen is showing.
+  onStepChange?: (step: 'button' | 'mfa-setup' | 'mfa-verify' | 'locked') => void;
+}> = ({ onLogin, onStepChange }) => {
   const [error, setError] = useState(``);
   const [loading, setLoading] = useState(false);
   const [mfaStep, setMfaStep] = useState<AuthStep | null>(null);
   const { setAuthData, config, authorizerRef } = useAuthorizer();
+
+  useEffect(() => {
+    if (!onStepChange) return;
+    if (mfaStep?.kind === 'locked') {
+      onStepChange('locked');
+    } else if (mfaStep?.kind === 'offer') {
+      onStepChange('mfa-setup');
+    } else if (mfaStep?.kind === 'verify') {
+      onStepChange('mfa-verify');
+    } else {
+      onStepChange('button');
+    }
+  }, [mfaStep?.kind]);
 
   // When the org enforces MFA, passkey must never be offered as a
   // standalone primary-login path - it would let a user skip the org's
@@ -69,22 +88,17 @@ export const AuthorizerPasskeyLogin: FC<{
   // exact set of conditions AuthorizerRoot uses to decide whether
   // AuthorizerSocialLogin, AuthorizerBasicAuthLogin, or
   // AuthorizerMagicLinkLogin render anything on the login view.
-  const hasSocialLogin =
-    config.is_google_login_enabled ||
-    config.is_github_login_enabled ||
-    config.is_facebook_login_enabled ||
-    config.is_linkedin_login_enabled ||
-    config.is_apple_login_enabled ||
-    config.is_twitter_login_enabled ||
-    config.is_microsoft_login_enabled ||
-    config.is_twitch_login_enabled ||
-    config.is_roblox_login_enabled;
+  // Deliberately excludes hasSocialLogin: social login always renders above
+  // this button in every known composition (AuthorizerRoot, web/app's
+  // login.tsx), so it's never "below" the passkey button - counting it here
+  // produced a second, redundant "OR" stacked under the first one AND a
+  // dangling "OR" with nothing beneath when social was the only other method.
   const hasBasicAuthLogin =
     (config.is_basic_authentication_enabled ||
       config.is_mobile_basic_authentication_enabled) &&
     !config.is_magic_link_login_enabled;
   const hasAnotherLoginMethod =
-    hasSocialLogin || hasBasicAuthLogin || config.is_magic_link_login_enabled;
+    hasBasicAuthLogin || config.is_magic_link_login_enabled;
 
   // A cancelled ceremony or an account with no passkey surfaces as
   // NotAllowedError/AbortError (the browser deliberately does not distinguish
@@ -149,6 +163,7 @@ export const AuthorizerPasskeyLogin: FC<{
         }}
         totpEnrollment={mfaStep.totpEnrollment || undefined}
         heading="Set up multi-factor authentication"
+        onBack={() => setMfaStep(null)}
         loginContext={{
           onComplete: (data) => {
             setAuthData({
@@ -176,6 +191,7 @@ export const AuthorizerPasskeyLogin: FC<{
         is_totp={mfaStep.totp}
         offerWebauthnVerify={mfaStep.webauthn}
         hasCodeFactor={mfaStep.totp || mfaStep.email || mfaStep.mobile}
+        onBack={() => setMfaStep(null)}
         onLogin={(data) => {
           setAuthData({
             user: data?.user || null,

--- a/src/components/AuthorizerPasskeyLogin.tsx
+++ b/src/components/AuthorizerPasskeyLogin.tsx
@@ -8,6 +8,7 @@ import { StyledButton, StyledSeparator } from '../styledComponents';
 import { Message } from './Message';
 import { AuthorizerMFASetup } from './AuthorizerMFASetup';
 import { AuthorizerMfaLocked } from './AuthorizerMfaLocked';
+import { AuthorizerVerifyOtp } from './AuthorizerVerifyOtp';
 import { resolveAuthStep, AuthStep } from '../utils/mfaTriage';
 
 // AuthorizerPasskeyLogin offers a full passwordless, usernameless "Sign in
@@ -142,7 +143,7 @@ export const AuthorizerPasskeyLogin: FC<{
       <AuthorizerMFASetup
         availableMfaMethods={{
           totp: !!mfaStep.totpEnrollment || config.is_totp_mfa_enabled,
-          passkey: false,
+          passkey: mfaStep.passkey,
           emailOtp: mfaStep.emailOtp,
           smsOtp: mfaStep.smsOtp,
         }}
@@ -166,16 +167,26 @@ export const AuthorizerPasskeyLogin: FC<{
   }
   if (mfaStep?.kind === 'verify') {
     // A passkey-primary login that still needs a second factor has no
-    // email/phone_number in hand (usernameless login) - the existing
-    // AuthorizerVerifyOtp component requires one of those to identify the
-    // pending user via the MFA session cookie, so TOTP/email/SMS verify
-    // can't be completed from here. This is a real, narrower gap than the
-    // password-login path (which always has an email/phone from the form) -
-    // report it plainly rather than rendering a broken form.
+    // email/phone_number in hand (usernameless login). AuthorizerVerifyOtp
+    // still works here: verify_otp/resend_otp resolve the pending user from
+    // the MFA session cookie alone when no identifier is supplied (the same
+    // session-only path the OAuth-return continuation uses).
     return (
-      <Message
-        type={MessageType.Error}
-        text="Additional verification is required. Please sign in with your password instead to continue."
+      <AuthorizerVerifyOtp
+        is_totp={mfaStep.totp}
+        offerWebauthnVerify={mfaStep.webauthn}
+        hasCodeFactor={mfaStep.totp || mfaStep.email || mfaStep.mobile}
+        onLogin={(data) => {
+          setAuthData({
+            user: data?.user || null,
+            token: data,
+            config,
+            loading: false,
+          });
+          if (onLogin) {
+            onLogin(data);
+          }
+        }}
       />
     );
   }

--- a/src/components/AuthorizerPasskeyRegister.tsx
+++ b/src/components/AuthorizerPasskeyRegister.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useState } from 'react';
 import {
-  GenericResponse,
+  AuthToken,
   WebauthnCredentialInfo,
   isWebauthnSupported,
 } from '@authorizerdev/authorizer-js';
@@ -21,8 +21,10 @@ import { Message } from './Message';
 // browser can't run the WebAuthn JSON ceremony, since in a settings context
 // the user needs to know why the option is missing.
 export const AuthorizerPasskeyRegister: FC<{
-  // Called after a passkey is successfully registered.
-  onSuccess?: (data: GenericResponse | void) => void;
+  // Called after a passkey is successfully registered. On the mfaSetup path
+  // (below) this carries access_token when registration also completed a
+  // withheld MFA offer - a plain settings-page add never sets it.
+  onSuccess?: (data: AuthToken | void) => void;
   // Optional friendly name for the credential (e.g. "MacBook Touch ID").
   // When omitted a small inline field is shown so the user can name it.
   name?: string;
@@ -30,7 +32,11 @@ export const AuthorizerPasskeyRegister: FC<{
   // Requires an authenticated session; off by default so Storybook and
   // unauthenticated hosts don't trigger a failing request.
   showCredentials?: boolean;
-}> = ({ onSuccess, name, showCredentials = false }) => {
+  // Present only during a token-withheld login-time MFA offer: authenticates
+  // the ceremony via the MFA session cookie instead of a bearer token (there
+  // isn't one yet), and completing it issues the previously-withheld token.
+  mfaSetup?: { email?: string; phoneNumber?: string; state?: string };
+}> = ({ onSuccess, name, showCredentials = false, mfaSetup }) => {
   const { authorizerRef } = useAuthorizer();
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
@@ -76,7 +82,8 @@ export const AuthorizerPasskeyRegister: FC<{
       setLoading(true);
       const trimmed = credentialName.trim();
       const { data, errors } = await authorizerRef.registerPasskey(
-        trimmed || undefined
+        trimmed || undefined,
+        mfaSetup
       );
       if (errors && errors.length) {
         setError(errors[0]?.message || 'Could not add passkey.');

--- a/src/components/AuthorizerResetPassword.tsx
+++ b/src/components/AuthorizerResetPassword.tsx
@@ -6,6 +6,7 @@ import { useAuthorizer } from '../contexts/AuthorizerContext';
 import { StyledButton, StyledWrapper } from '../styledComponents';
 import { formatErrorMessage } from '../utils/format';
 import { Message } from './Message';
+import { PasswordInput } from './PasswordInput';
 import { getSearchParams } from '../utils/url';
 import PasswordStrengthIndicator from './PasswordStrengthIndicator';
 
@@ -163,54 +164,24 @@ export const AuthorizerResetPassword: FC<Props> = ({
             )}
           </div>
         )}
-        <div className="styled-form-group">
-          <label
-            className="form-input-label"
-            htmlFor="authorizer-reset-password"
-          >
-            <span>* </span>Password
-          </label>
-          <input
-            name="password"
-            id="authorizer-reset-password"
-            className={`form-input-field ${
-              errorData.password ? 'input-error-content' : ''
-            }`}
-            placeholder="********"
-            type="password"
-            value={formData.password || ''}
-            onChange={(e) => onInputChange('password', e.target.value)}
-          />
-          {errorData.password && (
-            <div className="form-input-error">
-              {errorData.password}
-            </div>
-          )}
-        </div>
-        <div className="styled-form-group">
-          <label
-            className="form-input-label"
-            htmlFor="authorizer-reset-confirm-password"
-          >
-            <span>* </span>Confirm Password
-          </label>
-          <input
-            name="confirmPassword"
-            id="authorizer-reset-confirm-password"
-            className={`form-input-field ${
-              errorData.confirmPassword ? 'input-error-content' : ''
-            }`}
-            placeholder="********"
-            type="password"
-            value={formData.confirmPassword || ''}
-            onChange={(e) => onInputChange('confirmPassword', e.target.value)}
-          />
-          {errorData.confirmPassword && (
-            <div className="form-input-error">
-              {errorData.confirmPassword}
-            </div>
-          )}
-        </div>
+        <PasswordInput
+          id="authorizer-reset-password"
+          name="password"
+          label="Password"
+          autoComplete="new-password"
+          value={formData.password || ''}
+          onChange={(value) => onInputChange('password', value)}
+          error={errorData.password}
+        />
+        <PasswordInput
+          id="authorizer-reset-confirm-password"
+          name="confirmPassword"
+          label="Confirm Password"
+          autoComplete="new-password"
+          value={formData.confirmPassword || ''}
+          onChange={(value) => onInputChange('confirmPassword', value)}
+          error={errorData.confirmPassword}
+        />
         {config.is_strong_password_enabled && (
           <>
             <PasswordStrengthIndicator

--- a/src/components/AuthorizerRoot.tsx
+++ b/src/components/AuthorizerRoot.tsx
@@ -25,6 +25,10 @@ export const AuthorizerRoot: FC<{
   onPasswordReset?: () => void;
   roles?: string[];
 	signupFieldsOverrides?: FormFieldsOverrides
+  // When present, a "Back" link is shown on the MFA setup/verify screens
+  // (URL-param-driven, see mfaRedirect below) so the host can send the user
+  // somewhere sane - e.g. back to the login URL with the mfa params cleared.
+  onCancelMfa?: () => void;
 }> = ({
   onLogin,
   onSignup,
@@ -32,9 +36,24 @@ export const AuthorizerRoot: FC<{
   onForgotPassword,
   onPasswordReset,
   roles,
-	signupFieldsOverrides
+	signupFieldsOverrides,
+  onCancelMfa,
 }) => {
   const [view, setView] = useState(Views.Login);
+  // AuthorizerPasskeyLogin and AuthorizerBasicAuthLogin each take over the
+  // whole login surface once their own sign-in needs a second factor (their
+  // own MFA setup/verify/locked screens) - every other login option, and the
+  // login attempt not currently in flight, don't belong stacked on top of
+  // those screens.
+  const [passkeyStep, setPasskeyStep] = useState<
+    'button' | 'mfa-setup' | 'mfa-verify' | 'locked'
+  >('button');
+  const [basicAuthStep, setBasicAuthStep] = useState<
+    'form' | 'mfa-setup' | 'otp-verify' | 'locked'
+  >('form');
+  const passkeyIdle = passkeyStep === 'button';
+  const basicAuthIdle = basicAuthStep === 'form';
+  const showChrome = passkeyIdle && basicAuthIdle;
   const { config, configLoadError } = useAuthorizer();
   const searchParams = new URLSearchParams(
     hasWindow() ? window.location.search : ``
@@ -85,6 +104,7 @@ export const AuthorizerRoot: FC<{
             mfaRedirect.mfaMethods.includes('email_otp') ||
             mfaRedirect.mfaMethods.includes('sms_otp')
           }
+          onBack={onCancelMfa}
           onLogin={(data: any) => {
             if (onLogin) {
               onLogin(data);
@@ -101,6 +121,7 @@ export const AuthorizerRoot: FC<{
             smsOtp: mfaRedirect.mfaMethods.includes('sms_otp'),
           }}
           heading="Set up multi-factor authentication"
+          onBack={onCancelMfa}
           loginContext={{
             onComplete: (data: any) => {
               if (onLogin) {
@@ -110,14 +131,15 @@ export const AuthorizerRoot: FC<{
           }}
         />
       )}
-      {!mfaRedirect && view === Views.Login && (
+      {!mfaRedirect && view === Views.Login && showChrome && (
         <AuthorizerSocialLogin urlProps={urlProps} roles={roles} />
       )}
-      {!mfaRedirect && view === Views.Login && (
-        <AuthorizerPasskeyLogin onLogin={onLogin} />
+      {!mfaRedirect && view === Views.Login && basicAuthIdle && (
+        <AuthorizerPasskeyLogin onLogin={onLogin} onStepChange={setPasskeyStep} />
       )}
       {!mfaRedirect &&
         view === Views.Login &&
+        passkeyIdle &&
         (config.is_basic_authentication_enabled ||
           config.is_mobile_basic_authentication_enabled) &&
         !config.is_magic_link_login_enabled && (
@@ -126,6 +148,7 @@ export const AuthorizerRoot: FC<{
             onLogin={onLogin}
             urlProps={urlProps}
             roles={roles}
+            onStepChange={setBasicAuthStep}
           />
         )}
 
@@ -143,13 +166,16 @@ export const AuthorizerRoot: FC<{
           />
         )}
 
-      {!mfaRedirect && view === Views.Login && config.is_magic_link_login_enabled && (
-        <AuthorizerMagicLinkLogin
-          onMagicLinkLogin={onMagicLinkLogin}
-          urlProps={urlProps}
-          roles={roles}
-        />
-      )}
+      {!mfaRedirect &&
+        view === Views.Login &&
+        showChrome &&
+        config.is_magic_link_login_enabled && (
+          <AuthorizerMagicLinkLogin
+            onMagicLinkLogin={onMagicLinkLogin}
+            urlProps={urlProps}
+            roles={roles}
+          />
+        )}
 
       {view === Views.ForgotPassword && (
         <AuthorizerForgotPassword

--- a/src/components/AuthorizerRoot.tsx
+++ b/src/components/AuthorizerRoot.tsx
@@ -12,6 +12,7 @@ import { AuthorizerSocialLogin } from './AuthorizerSocialLogin';
 import { AuthorizerPasskeyLogin } from './AuthorizerPasskeyLogin';
 import { AuthorizerMagicLinkLogin } from './AuthorizerMagicLinkLogin';
 import { AuthorizerMFASetup } from './AuthorizerMFASetup';
+import { AuthorizerVerifyOtp } from './AuthorizerVerifyOtp';
 import { Message } from './Message';
 import { createRandomString } from '../utils/common';
 import { hasWindow } from '../utils/window';
@@ -71,11 +72,31 @@ export const AuthorizerRoot: FC<{
           text={`Unable to reach the Authorizer server (${configLoadError}). Login methods that depend on it - such as basic auth, signup, and social login - won't appear until it's reachable.`}
         />
       )}
-      {mfaRedirect && (
+      {mfaRedirect && mfaRedirect.mfaGate === 'verify' && (
+        // An already-configured factor must be challenged, not offered setup
+        // again - no email/phone_number in hand (OAuth/magic-link return),
+        // but verify_otp resolves the pending user from the MFA session
+        // cookie alone, same as the passkey-primary-login continuation.
+        <AuthorizerVerifyOtp
+          is_totp={mfaRedirect.mfaMethods.includes('totp')}
+          offerWebauthnVerify={mfaRedirect.mfaMethods.includes('webauthn')}
+          hasCodeFactor={
+            mfaRedirect.mfaMethods.includes('totp') ||
+            mfaRedirect.mfaMethods.includes('email_otp') ||
+            mfaRedirect.mfaMethods.includes('sms_otp')
+          }
+          onLogin={(data: any) => {
+            if (onLogin) {
+              onLogin(data);
+            }
+          }}
+        />
+      )}
+      {mfaRedirect && mfaRedirect.mfaGate === 'offer' && (
         <AuthorizerMFASetup
           availableMfaMethods={{
             totp: mfaRedirect.mfaMethods.includes('totp'),
-            passkey: false,
+            passkey: mfaRedirect.mfaMethods.includes('webauthn'),
             emailOtp: mfaRedirect.mfaMethods.includes('email_otp'),
             smsOtp: mfaRedirect.mfaMethods.includes('sms_otp'),
           }}

--- a/src/components/AuthorizerSignup.tsx
+++ b/src/components/AuthorizerSignup.tsx
@@ -50,6 +50,7 @@ type MfaOfferData = {
   email: string;
   phone_number: string;
   totpEnrollment: TotpEnrollment | null;
+  passkey: boolean;
   emailOtp: boolean;
   smsOtp: boolean;
   state?: string;
@@ -60,6 +61,7 @@ const initMfaOfferData: MfaOfferData = {
   email: '',
   phone_number: '',
   totpEnrollment: null,
+  passkey: false,
   emailOtp: false,
   smsOtp: false,
 };
@@ -173,6 +175,7 @@ export const AuthorizerSignup: FC<{
           email: data.email || ``,
           phone_number: data.phone_number || ``,
           totpEnrollment: step.totpEnrollment,
+          passkey: step.passkey,
           emailOtp: step.emailOtp,
           smsOtp: step.smsOtp,
           state: urlProps?.state,
@@ -315,7 +318,7 @@ export const AuthorizerSignup: FC<{
       <AuthorizerMFASetup
         availableMfaMethods={{
           totp: !!mfaOfferData.totpEnrollment || config.is_totp_mfa_enabled,
-          passkey: false,
+          passkey: mfaOfferData.passkey,
           emailOtp: mfaOfferData.emailOtp,
           smsOtp: mfaOfferData.smsOtp,
         }}

--- a/src/components/AuthorizerSignup.tsx
+++ b/src/components/AuthorizerSignup.tsx
@@ -9,6 +9,7 @@ import { useAuthorizer } from '../contexts/AuthorizerContext';
 import { StyledButton, StyledFooter, StyledLink } from '../styledComponents';
 import { formatErrorMessage } from '../utils/format';
 import { Message } from './Message';
+import { PasswordInput } from './PasswordInput';
 import PasswordStrengthIndicator from './PasswordStrengthIndicator';
 import { OtpDataType } from '../types';
 import { AuthorizerVerifyOtp } from './AuthorizerVerifyOtp';
@@ -66,13 +67,21 @@ const initMfaOfferData: MfaOfferData = {
   smsOtp: false,
 };
 
+export type SignupStep = 'form' | 'mfa-setup' | 'otp-verify' | 'locked';
+
 export const AuthorizerSignup: FC<{
   setView?: (v: Views) => void;
   onSignup?: (data: AuthToken) => void;
   urlProps?: Record<string, any>;
   roles?: string[];
   fieldOverrides?: FormFieldsOverrides;
-}> = ({ setView, onSignup, urlProps, roles, fieldOverrides }) => {
+  // Fired whenever this component switches between its own internal
+  // screens. Hosts that render other login options (e.g. "Continue with
+  // Google") alongside the signup form need this to hide them once the
+  // account exists and the user has moved on to MFA setup/verification -
+  // those options no longer make sense on top of those screens.
+  onStepChange?: (step: SignupStep) => void;
+}> = ({ setView, onSignup, urlProps, roles, fieldOverrides, onStepChange }) => {
   const [error, setError] = useState(``);
   const [loading, setLoading] = useState(false);
   const [otpData, setOtpData] = useState<OtpDataType>({ ...initOtpData });
@@ -97,6 +106,19 @@ export const AuthorizerSignup: FC<{
   });
   const { authorizerRef, config, setAuthData } = useAuthorizer();
   const [disableSignupButton, setDisableSignupButton] = useState(false);
+
+  useEffect(() => {
+    if (!onStepChange) return;
+    if (locked) {
+      onStepChange('locked');
+    } else if (mfaOfferData.is_screen_visible) {
+      onStepChange('mfa-setup');
+    } else if (otpData.is_screen_visible) {
+      onStepChange('otp-verify');
+    } else {
+      onStepChange('form');
+    }
+  }, [locked, mfaOfferData.is_screen_visible, otpData.is_screen_visible]);
 
   const onInputChange = async (field: string, value: string) =>
     setFormData({ ...formData, [field]: value });
@@ -324,6 +346,7 @@ export const AuthorizerSignup: FC<{
         }}
         totpEnrollment={mfaOfferData.totpEnrollment || undefined}
         heading="Set up multi-factor authentication"
+        onBack={() => setMfaOfferData({ ...initMfaOfferData })}
         loginContext={{
           email: mfaOfferData.email,
           phone_number: mfaOfferData.phone_number,
@@ -359,6 +382,7 @@ export const AuthorizerSignup: FC<{
             is_totp: otpData.is_totp || false,
             offerWebauthnVerify: otpData.offer_webauthn_verify || false,
             hasCodeFactor: otpData.has_code_factor || false,
+            onBack: () => setOtpData({ ...initOtpData }),
           }}
           urlProps={urlProps}
         />
@@ -375,6 +399,20 @@ export const AuthorizerSignup: FC<{
     const fieldOverride = fieldOverrides?.[key];
     if (fieldOverride?.hide) {
       return null;
+    }
+    if (type === 'password') {
+      return (
+        <PasswordInput
+          id={`authorizer-sign-up-${key}`}
+          name={key}
+          label={fieldOverride?.label ?? label}
+          placeholder={fieldOverride?.placeholder ?? placeholder}
+          autoComplete={key === 'password' ? 'new-password' : 'off'}
+          value={formData[key] || ''}
+          onChange={(value) => onInputChange(key, value)}
+          error={errorData[key]}
+        />
+      );
     }
     return (
       <div className="styled-form-group">

--- a/src/components/AuthorizerSocialLogin.tsx
+++ b/src/components/AuthorizerSocialLogin.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import { isWebauthnSupported } from '@authorizerdev/authorizer-js';
 import { Github } from '../icons/github';
 import { Google } from '../icons/google';
 import { Facebook } from '../icons/facebook';
@@ -28,6 +29,10 @@ export const AuthorizerSocialLogin: FC<{
     config.is_microsoft_login_enabled ||
     config.is_twitch_login_enabled ||
     config.is_roblox_login_enabled;
+  // AuthorizerPasskeyLogin always renders immediately after this component
+  // (AuthorizerRoot, web/app's login.tsx) and owns its own "OR" separator
+  // for whatever follows it - suppress this one so the two don't stack.
+  const willShowPasskey = isWebauthnSupported() && !config.is_mfa_enforced;
 
   const data: {
     scope?: string;
@@ -178,6 +183,7 @@ export const AuthorizerSocialLogin: FC<{
         </>
       )}
       {hasSocialLogin &&
+        !willShowPasskey &&
         (config.is_basic_authentication_enabled ||
           config.is_mobile_basic_authentication_enabled ||
           config.is_magic_link_login_enabled) && (

--- a/src/components/AuthorizerVerifyOtp.tsx
+++ b/src/components/AuthorizerVerifyOtp.tsx
@@ -57,11 +57,11 @@ export const AuthorizerVerifyOtp: FC<{
     otp: null,
   });
   const { authorizerRef, config, setAuthData } = useAuthorizer();
-  useEffect(() => {
-    if (!email && !phone_number) {
-      setError(`Email or Phone Number is required`);
-    }
-  }, []);
+  // No email/phone_number is a legitimate state here, not an error: the
+  // OAuth-return and passkey-primary-login MFA continuations resolve the
+  // pending user from the MFA session cookie alone (see verify_otp.go's
+  // sessionResolved path) - the frontend never learns their email/phone in
+  // those flows.
 
   const [webauthnError, setWebauthnError] = useState(``);
   const [webauthnLoading, setWebauthnLoading] = useState(false);

--- a/src/components/AuthorizerVerifyOtp.tsx
+++ b/src/components/AuthorizerVerifyOtp.tsx
@@ -1,11 +1,15 @@
 import { FC, useEffect, useState } from 'react';
-import { VerifyOTPRequest, isWebauthnSupported } from '@authorizerdev/authorizer-js';
+import {
+  VerifyOTPRequest,
+  isWebauthnSupported,
+} from '@authorizerdev/authorizer-js';
 import '../styles/default.css';
 
 import { ButtonAppearance, MessageType, Views } from '../constants';
 import { useAuthorizer } from '../contexts/AuthorizerContext';
 import { StyledButton, StyledFooter, StyledLink } from '../styledComponents';
 import { Message } from './Message';
+import { BackLink } from './BackLink';
 import { TotpDataType } from '../types';
 import { AuthorizerTOTPScanner } from './AuthorizerTOTPScanner';
 import { AuthorizerMfaLocked } from './AuthorizerMfaLocked';
@@ -34,6 +38,10 @@ export const AuthorizerVerifyOtp: FC<{
   is_totp?: boolean;
   offerWebauthnVerify?: boolean;
   hasCodeFactor?: boolean;
+  // When present, a "Back" link lets the user leave this challenge (e.g.
+  // return to the login screen) instead of being stuck once a factor is
+  // being verified.
+  onBack?: () => void;
 }> = ({
   setView,
   onLogin,
@@ -43,6 +51,7 @@ export const AuthorizerVerifyOtp: FC<{
   is_totp,
   offerWebauthnVerify,
   hasCodeFactor,
+  onBack,
 }) => {
   const [error, setError] = useState(``);
   const [successMessage, setSuccessMessage] = useState(``);
@@ -64,6 +73,10 @@ export const AuthorizerVerifyOtp: FC<{
   // those flows.
 
   const [webauthnError, setWebauthnError] = useState(``);
+  // Distinct from webauthnError: the passkey ceremony itself succeeded, this
+  // just tells the user a second factor is still needed - showing that as a
+  // red error would read as "your passkey failed," which it didn't.
+  const [webauthnNotice, setWebauthnNotice] = useState(``);
   const [webauthnLoading, setWebauthnLoading] = useState(false);
   const [webauthnLocked, setWebauthnLocked] = useState(false);
   const passkeySupported = isWebauthnSupported();
@@ -76,6 +89,7 @@ export const AuthorizerVerifyOtp: FC<{
 
   const onVerifyWithPasskey = async () => {
     setWebauthnError(``);
+    setWebauthnNotice(``);
     try {
       setWebauthnLoading(true);
       const { data: res, errors } = await authorizerRef.loginWithPasskey(email);
@@ -108,8 +122,8 @@ export const AuthorizerVerifyOtp: FC<{
         return;
       }
       if (step.kind === 'verify') {
-        setWebauthnError(
-          `Additional verification is still required after passkey. Please use the code form below instead.`,
+        setWebauthnNotice(
+          `Your passkey was verified. Enter the code below to finish signing in.`
         );
         return;
       }
@@ -162,7 +176,7 @@ export const AuthorizerVerifyOtp: FC<{
           // returns null for blank text) and the form goes silently dead.
           setError(
             errors[0]?.message ||
-              `Too many attempts. Please wait a while before trying again.`,
+              `Too many attempts. Please wait a while before trying again.`
           );
           return;
         }
@@ -293,6 +307,7 @@ export const AuthorizerVerifyOtp: FC<{
 
   return (
     <>
+      {onBack && <BackLink onClick={onBack} />}
       {successMessage && (
         <Message
           type={MessageType.Success}
@@ -314,11 +329,16 @@ export const AuthorizerVerifyOtp: FC<{
           onClose={() => setWebauthnError(``)}
         />
       )}
+      {webauthnNotice && (
+        <Message
+          type={MessageType.Info}
+          text={webauthnNotice}
+          onClose={() => setWebauthnNotice(``)}
+        />
+      )}
       {offerWebauthnVerify && passkeySupported && (
         <>
-          <p style={{ textAlign: 'center', margin: '10px 0px' }}>
-            Verify with your passkey
-          </p>
+          <p style={{ margin: '10px 0px' }}>Verify with your passkey</p>
           <StyledButton
             type="button"
             appearance={ButtonAppearance.Default}
@@ -334,7 +354,9 @@ export const AuthorizerVerifyOtp: FC<{
               }}
             >
               <IconPasskey />
-              {webauthnLoading ? `Waiting for passkey ...` : `Verify with a passkey`}
+              {webauthnLoading
+                ? `Waiting for passkey ...`
+                : `Verify with a passkey`}
             </span>
           </StyledButton>
           <br />
@@ -352,17 +374,19 @@ export const AuthorizerVerifyOtp: FC<{
       {showCodeForm && (
         <>
           {offerWebauthnVerify && passkeySupported && (
-            <p style={{ textAlign: 'center', margin: '10px 0px' }}>
-              Or enter a code instead
-            </p>
+            <p style={{ margin: '10px 0px' }}>Or enter a code instead</p>
           )}
-          <p style={{ textAlign: 'center', margin: '10px 0px' }}>
-            Please enter the OTP sent to your email or phone number or authenticator
+          <p style={{ margin: '10px 0px' }}>
+            Please enter the OTP sent to your email or phone number or
+            authenticator
           </p>
           <br />
           <form onSubmit={onSubmit} name="authorizer-mfa-otp-form">
             <div className="styled-form-group">
-              <label className="form-input-label" htmlFor="authorizer-verify-otp">
+              <label
+                className="form-input-label"
+                htmlFor="authorizer-verify-otp"
+              >
                 <span>* </span>OTP (One Time Password)
               </label>
               <input
@@ -394,7 +418,9 @@ export const AuthorizerVerifyOtp: FC<{
             <br />
             <StyledButton
               type="submit"
-              disabled={loading || !formData.otp || !!errorData.otp || isLockedOut}
+              disabled={
+                loading || !formData.otp || !!errorData.otp || isLockedOut
+              }
               appearance={ButtonAppearance.Primary}
             >
               {loading ? `Processing ...` : `Submit`}

--- a/src/components/BackLink.tsx
+++ b/src/components/BackLink.tsx
@@ -1,0 +1,35 @@
+import { FC } from 'react';
+
+const ArrowLeftIcon: FC<{ size?: number }> = ({ size = 16 }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    style={{ width: size, height: size, display: 'block' }}
+    aria-hidden="true"
+  >
+    <path d="M19 12H5M12 19l-7-7 7-7" />
+  </svg>
+);
+
+// The one back-navigation control every MFA/OTP screen uses - kept at the
+// top of the screen (not the bottom) so it's the first thing a user sees
+// when they land on a multi-step or content-heavy screen (e.g. the TOTP
+// scanner with recovery codes below it), not something they have to scroll
+// past a form to find.
+export const BackLink: FC<{ onClick: () => void; label?: string }> = ({
+  onClick,
+  label = 'Back',
+}) => (
+  <button
+    type="button"
+    className="mfa-icon-button mfa-back-link"
+    onClick={onClick}
+  >
+    <ArrowLeftIcon />
+    {label}
+  </button>
+);

--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -1,0 +1,61 @@
+import { FC, useState } from 'react';
+import { IconEye, IconEyeOff } from '../icons/eye';
+
+// Shared by every real password field (login, signup, reset password) - not
+// used for the OTP code input, which is masked with type="password" for the
+// same visual treatment but isn't a password a user would want to reveal.
+export const PasswordInput: FC<{
+  id: string;
+  name: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  error?: string | null;
+  placeholder?: string;
+  autoComplete?: string;
+  disabled?: boolean;
+}> = ({
+  id,
+  name,
+  label,
+  value,
+  onChange,
+  error,
+  placeholder = '********',
+  autoComplete,
+  disabled,
+}) => {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <div className="styled-form-group">
+      <label className="form-input-label" htmlFor={id}>
+        <span>* </span>
+        {label}
+      </label>
+      <div className="password-input-wrapper">
+        <input
+          name={name}
+          id={id}
+          className={`form-input-field ${error ? 'input-error-content' : ''}`}
+          placeholder={placeholder}
+          type={visible ? 'text' : 'password'}
+          autoComplete={autoComplete}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled}
+        />
+        <button
+          type="button"
+          className="password-toggle-button"
+          onClick={() => setVisible((v) => !v)}
+          aria-label={visible ? 'Hide password' : 'Show password'}
+          tabIndex={-1}
+        >
+          {visible ? <IconEyeOff /> : <IconEye />}
+        </button>
+      </div>
+      {error && <div className="form-input-error">{error}</div>}
+    </div>
+  );
+};

--- a/src/icons/eye.tsx
+++ b/src/icons/eye.tsx
@@ -1,0 +1,43 @@
+import { FC } from 'react';
+
+type IconProps = {
+  size?: number;
+};
+
+const base = (size: number) => ({
+  width: `${size}px`,
+  height: `${size}px`,
+  display: 'block',
+});
+
+export const IconEye: FC<IconProps> = ({ size = 18 }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    style={base(size)}
+    aria-hidden="true"
+  >
+    <path d="M1.5 12S5 5 12 5s10.5 7 10.5 7-3.5 7-10.5 7-10.5-7-10.5-7Z" />
+    <circle cx="12" cy="12" r="3" />
+  </svg>
+);
+
+export const IconEyeOff: FC<IconProps> = ({ size = 18 }) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    style={base(size)}
+    aria-hidden="true"
+  >
+    <path d="M17.94 17.94A10.5 10.5 0 0 1 12 19.5C5 19.5 1.5 12 1.5 12a19.1 19.1 0 0 1 4.22-5.44M9.9 4.66A10.8 10.8 0 0 1 12 4.5c7 0 10.5 7.5 10.5 7.5a19.15 19.15 0 0 1-2.16 3.19M14.12 14.12a3 3 0 1 1-4.24-4.24" />
+    <path d="M1.5 1.5l21 21" />
+  </svg>
+);

--- a/src/styles/default.css
+++ b/src/styles/default.css
@@ -81,6 +81,31 @@
   color: red;
   border-color: var(--authorizer-danger-color);
 }
+.password-input-wrapper {
+  position: relative;
+}
+.password-input-wrapper .form-input-field {
+  padding-right: 40px;
+}
+.password-toggle-button {
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(calc(-50% + 2.5px));
+  background: none;
+  border: none;
+  padding: 4px;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--authorizer-text-color);
+  opacity: 0.6;
+}
+.password-toggle-button:hover {
+  opacity: 1;
+}
 .styled-link {
   color: var(--authorizer-primary-color);
   cursor: pointer;
@@ -176,6 +201,22 @@
 .mfa-method-title {
   margin: 0;
   font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.mfa-method-enabled {
+  border-color: var(--authorizer-success-color);
+}
+.mfa-method-badge {
+  font-size: var(--authorizer-fonts-tiny-text);
+  font-weight: 600;
+  color: var(--authorizer-success-color);
+  border: 1px solid var(--authorizer-success-color);
+  border-radius: var(--authorizer-radius-card);
+  padding: 2px 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
 }
 .mfa-method-desc {
   margin: 2px 0 0;
@@ -264,6 +305,10 @@
 .mfa-icon-button:focus-visible {
   outline: 2px solid var(--authorizer-primary-color);
   outline-offset: 2px;
+}
+.mfa-back-link {
+  margin-bottom: 14px;
+  min-height: 36px;
 }
 
 /* ---------- recovery codes ---------- */

--- a/src/utils/mfaTriage.ts
+++ b/src/utils/mfaTriage.ts
@@ -25,11 +25,11 @@ export type AuthStep =
   | {
       kind: 'offer';
       totpEnrollment: TotpEnrollment | null;
-      // Passkey is intentionally excluded from the offer surface here - see
-      // this plan's Global Constraints: webauthn_registration_options/verify
-      // require a bearer token that doesn't exist in this withheld-token
-      // state, a known backend gap tracked separately, not fixed by this
-      // component.
+      // should_offer_webauthn_mfa_setup: the server-authenticated signal that
+      // passkey enrollment is available here. webauthn_registration_options/
+      // verify authenticate via the MFA session cookie on this path (no
+      // bearer token yet) - see AuthorizerMFASetup's mfaSetup prop.
+      passkey: boolean;
       emailOtp: boolean;
       smsOtp: boolean;
     }
@@ -100,6 +100,7 @@ export function resolveAuthStep(
   }
   if (
     hasTotpEnrollment ||
+    res.should_offer_webauthn_mfa_setup ||
     res.should_offer_email_otp_mfa_setup ||
     res.should_offer_sms_otp_mfa_setup
   ) {
@@ -112,6 +113,7 @@ export function resolveAuthStep(
             authenticator_recovery_codes: res.authenticator_recovery_codes as string[],
           }
         : null,
+      passkey: !!res.should_offer_webauthn_mfa_setup,
       emailOtp: !!res.should_offer_email_otp_mfa_setup,
       smsOtp: !!res.should_offer_sms_otp_mfa_setup,
     };


### PR DESCRIPTION
## Summary
- `AuthorizerMFASetup` now offers passkey as a real enrollment option during the login-time (token-withheld) MFA offer screen, wired through `AuthorizerBasicAuthLogin`/`AuthorizerSignup`/`AuthorizerRoot`/`AuthorizerPasskeyLogin` (all previously hardcoded `passkey: false`).
- OAuth/magic-link return now branches on the backend's new `mfa_gate` redirect param: renders `AuthorizerVerifyOtp` (challenge) for an already-configured factor instead of always showing the setup screen.
- `AuthorizerPasskeyLogin`'s "verify" step renders the real challenge form instead of telling the user to sign in with a password.
- Removed a stale `AuthorizerVerifyOtp` `useEffect` that misfired an "Email or Phone Number is required" error on the now-legitimate session-only resolution path.

**Depends on** authorizerdev/authorizer-js#47 (the SDK changes this consumes) and the corresponding backend PR on authorizerdev/authorizer (`feat/enforce-mfa-passkey-gate`).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] Manually verified against a local backend build: passkey "Set up" now renders on the MFA setup screen (screenshot-confirmed); `mfa_gate=verify` correctly renders the OTP challenge screen instead of setup
- [x] Full email-OTP MFA setup flow (setup → mailpit delivery → verify → token issued → next login challenges instead of re-offering) verified end to end against the linked SDK/backend changes