### PR TITLE
chore: bump @authorizerdev/authorizer-js to 3.3.0-rc.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.2.0-rc.2",
       "license": "MIT",
       "dependencies": {
-        "@authorizerdev/authorizer-js": "^3.3.0-rc.3",
+        "@authorizerdev/authorizer-js": "^3.3.0-rc.4",
         "@storybook/preset-scss": "^1.0.3",
         "validator": "^13.11.0"
       },
@@ -73,9 +73,9 @@
       }
     },
     "node_modules/@authorizerdev/authorizer-js": {
-      "version": "3.3.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-3.3.0-rc.3.tgz",
-      "integrity": "sha512-u2gs/srkiutn3j1DGPPiWEMkJj1G3lvHgAKVmo8ZzuOSrzU5hqHSrlSIrgQiuBEh6ozpGSnzsR251oz5FNJipA==",
+      "version": "3.3.0-rc.4",
+      "resolved": "https://registry.npmjs.org/@authorizerdev/authorizer-js/-/authorizer-js-3.3.0-rc.4.tgz",
+      "integrity": "sha512-OtI9bZOn5bLFPfMwXj0Eh9VOO04VEmoK3pr8vTsmb5ieejITRvFjMOm/tmCLTzIEE0uk0tToMAD3tkUSqGGBwQ==",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "@authorizerdev/authorizer-js": "^3.3.0-rc.3",
+    "@authorizerdev/authorizer-js": "^3.3.0-rc.4",
     "@storybook/preset-scss": "^1.0.3",
     "validator": "^13.11.0"
   }


### PR DESCRIPTION
## Summary
Bump `@authorizerdev/authorizer-js` from `3.3.0-rc.3` to `3.3.0-rc.4`.

Two breaking changes landed upstream between those versions:
- **authorizer-js#48** - removed `is_multi_factor_auth_enabled` from `SignUpRequest` (security fix closing a bypass of the server's MFA-on-by-default policy). Scoped to the signup path only; `UpdateProfileRequest`/admin `UpdateUserRequest` keep the field.
- **authorizer-js#50** - flattened `.webhooks()`/`.emailTemplates()`/`.verificationRequests()` pagination params (`PaginatedRequest` wrapper removed, `PaginationRequest` used directly).

## Impact on this package
None. Confirmed via repo-wide grep both before and after the bump:
- Nothing in `src/` sets `is_multi_factor_auth_enabled` on the signup request (`AuthorizerSignup.tsx`'s `SignUpRequest` literal doesn't include it).
- Nothing in `src/` imports `AuthorizerAdmin` or calls `.webhooks()`/`.emailTemplates()`/`.verificationRequests()` - those are admin-only methods this login-widget package never touches.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run build` passes